### PR TITLE
Use discard(button) instead of remove(button)

### DIFF
--- a/panda3d_kivy/core/window.py
+++ b/panda3d_kivy/core/window.py
@@ -100,7 +100,7 @@ class PandaMouse(DirectObject):
             if state == 'down':
                 self.buttons_down.add(button)
             else:
-                self.buttons_down.remove(button)
+                self.buttons_down.discard(button)
 
             self.on_mouse_event(state, self.coords, button)
 


### PR DESCRIPTION
Using remove(button) on line 103 raises an error if the button is not in self.buttons_down.

If you press shift, ctrl or alt and any mouse button, when you release the mouse button, the "remove (button)" raises a KeyError, because the button is not in self.buttons_down