### PR TITLE
Fixed underscore crash bug.

### DIFF
--- a/panda3d_kivy/core/window.py
+++ b/panda3d_kivy/core/window.py
@@ -205,7 +205,7 @@ class PandaWindow(WindowBase):
         if '-' not in text:
             return
 
-        modifier, text = text.split('-')
+        modifier, text = text.split('-', maxsplit = 1)
 
         if modifier not in self.modifier_keys:
             return


### PR DESCRIPTION
I have fixed a bug that causes an application to crash if the underscore char is typed. The bug was caused when the event string is "Shift--" because splitting that string results in a list of 3 strings instead of the expected list of 2 strings.