### PR TITLE
Fixed segfault on macOS Big Sur.

### DIFF
--- a/panda3d_kivy/monkey.py
+++ b/panda3d_kivy/monkey.py
@@ -6,7 +6,7 @@ import kivy.core
 
 def patch_kivy():
     os.environ['KIVY_WINDOW'] = ''
-    if sys.platform == 'linux':
+    if sys.platform == 'linux' or sys.platform == 'darwin':
         os.environ['KIVY_GL_BACKEND'] = 'gl'
 
     orig_core_select_lib = kivy.core.core_select_lib


### PR DESCRIPTION
On my macOS, Kivy will choose SDL2 as the default graphics backend. Perhaps Panda3D is not compatible with SDL2. So I just enforce the backend to GL and find it works well.

Environment:

Python 3.7.11
Panda3D 1.10.11
Kivy 2.1.0
macOS: Big Sur 11.6

Hope this PR is helpful.